### PR TITLE
Windows compatibility fixes

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -32,21 +32,33 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#define debug(X, ...)                                                    \
-  do {                                                                  \
-    struct tm td;                                                       \
-    struct timeval tv;                                                  \
-    struct timezone tz;                                                 \
-    FILE * out = stderr;                                                \
-    if (X) {                                                            \
-      gettimeofday (&tv, &tz);                                          \
-      localtime_r (&tv.tv_sec, &td);                                    \
-      fprintf (out, "(DEBUG %02d:%02d:%02d.%03d %s:%d %s) ", td.tm_hour, td.tm_min, td.tm_sec, static_cast <int> (tv.tv_usec / 1000), __FILE__, __LINE__, __FUNCTION__); \
-      fprintf (out, __VA_ARGS__);                                       \
-      fprintf (out, "\n");                                              \
-      fflush (out);                                                     \
-    }                                                                   \
-  } while (0);
-
+#ifdef _WIN32
+  #define debug(X, ...)                                                    \
+    do {                                                                  \
+      FILE * out = stdout;                                                \
+      if (X) {                                                            \
+        fprintf(out, "(DEBUG %s:%d %s)", __FILE__, __LINE__, __FUNCTION__); \
+        fprintf (out, __VA_ARGS__);                                       \
+        fprintf (out, "\n");                                              \
+        fflush (out);                                                     \
+      }                                                                   \
+    } while (0);
+#else
+  #define debug(X, ...)                                                    \
+    do {                                                                  \
+      struct tm td;                                                       \
+      struct timeval tv;                                                  \
+      struct timezone tz;                                                 \
+      FILE * out = stderr;                                                \
+      if (X) {                                                            \
+        gettimeofday (&tv, &tz);                                          \
+        localtime_r (&tv.tv_sec, &td);                                    \
+        fprintf (out, "(DEBUG %02d:%02d:%02d.%03d %s:%d %s) ", td.tm_hour, td.tm_min, td.tm_sec, static_cast <int> (tv.tv_usec / 1000), __FILE__, __LINE__, __FUNCTION__); \
+        fprintf (out, __VA_ARGS__);                                       \
+        fprintf (out, "\n");                                              \
+        fflush (out);                                                     \
+      }                                                                   \
+    } while (0);
+#endif // _WIN32
 
 #endif  // SRC_DEBUG_H__

--- a/src/emitter.cc
+++ b/src/emitter.cc
@@ -83,15 +83,15 @@ namespace fluent {
     // Setup socket.
     std::stringstream ss;
     ss << port;
-    Init(host, ss.str());
+    init(host, ss.str());
   }
   InetEmitter::InetEmitter(const std::string &host,
                            const std::string &port) :
     Emitter(), retry_limit_(0)
   {
-    Init(host, port);
+    init(host, port);
   }
-  void InetEmitter::Init(const std::string &host,
+  void InetEmitter::init(const std::string &host,
 						 const std::string &port) {
     // Setup random engine
     mt_rand = std::mt19937(random_device());

--- a/src/emitter.cc
+++ b/src/emitter.cc
@@ -34,7 +34,6 @@
 #include <math.h>
 #include <unistd.h>
 #include <errno.h>
-#include <random>
 
 #include "./fluent/emitter.hpp"
 #include "./debug.h"

--- a/src/emitter.cc
+++ b/src/emitter.cc
@@ -49,7 +49,7 @@ namespace fluent {
   }
 
   bool Emitter::emit(Message *msg) {
-    debug(false, "emit %p", msg);
+    debug(DBG, "emit %p", msg);
     bool rc = this->queue_.push(msg);
     return rc;
   }
@@ -108,8 +108,6 @@ namespace fluent {
   }
 
   bool InetEmitter::connect() {
-    static const bool DBG = false;
-
     for (size_t i = 0; this->retry_limit_ == 0 || i < this->retry_limit_;
          i++) {
 
@@ -153,8 +151,9 @@ namespace fluent {
         msgpack::packer <msgpack::sbuffer> pk(&buf);
         msg->to_msgpack(&pk);
 
-        debug(false, "sending msg %p", msg);
+        debug(DBG, "sending msg %p", msg);
         while(!this->sock_->send(buf.data(), buf.size())) {
+          debug(DBG, "socket error: %s", this->sock_->errmsg().c_str());
           // std::cerr << "socket error: " << this->sock_->errmsg() << std::endl;
           if (!this->connect()) {
             abort_loop = true;

--- a/src/emitter.cc
+++ b/src/emitter.cc
@@ -188,9 +188,12 @@ namespace fluent {
   }
   FileEmitter::FileEmitter(int fd) : Emitter(), fd_(fd),
                                      enabled_(false), opened_(false) {
+#ifndef _WIN32
     if (fcntl(fd, F_GETFL) < 0 && errno == EBADF) {
       this->set_errmsg("Invalid file descriptor");
-    } else {
+	} else
+#endif
+	{
       this->enabled_ = true;
       this->start_worker();
     }

--- a/src/fluent/emitter.hpp
+++ b/src/fluent/emitter.hpp
@@ -62,7 +62,7 @@ namespace fluent {
   private:
     static const int WAIT_MAX;
 
-    void Init(const std::string &host, const std::string &port);
+    void init(const std::string &host, const std::string &port);
 
     std::random_device random_device;
     std::mt19937 mt_rand;

--- a/src/fluent/emitter.hpp
+++ b/src/fluent/emitter.hpp
@@ -61,6 +61,12 @@ namespace fluent {
   private:
     static const int WAIT_MAX;
 
+    void Init(const std::string &host, const std::string &port);
+
+    std::random_device random_device;
+    std::mt19937 mt_rand;
+    std::uniform_int_distribution<int> rand_dist;
+
     Socket *sock_;
     size_t retry_limit_;
     bool connect();

--- a/src/fluent/emitter.hpp
+++ b/src/fluent/emitter.hpp
@@ -43,7 +43,7 @@ namespace fluent {
     virtual void worker() = 0;
     
   protected:
-    const bool DBG = true;
+    static const bool DBG = true;
     MsgThreadQueue queue_;
     void set_errmsg(const std::string &errmsg) {
       this->errmsg_ = errmsg;

--- a/src/fluent/emitter.hpp
+++ b/src/fluent/emitter.hpp
@@ -42,6 +42,7 @@ namespace fluent {
     virtual void worker() = 0;
     
   protected:
+    const bool DBG = true;
     MsgThreadQueue queue_;
     void set_errmsg(const std::string &errmsg) {
       this->errmsg_ = errmsg;

--- a/src/fluent/emitter.hpp
+++ b/src/fluent/emitter.hpp
@@ -29,6 +29,7 @@
 
 #include <string>
 #include <pthread.h>
+#include <random>
 #include "./socket.hpp"
 #include "./queue.hpp"
 

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -37,6 +37,12 @@
 
 namespace fluent {
   Logger::Logger() {
+#ifdef _WIN32
+      WORD wVersionRequested;
+      WSADATA wsaData;
+      wVersionRequested = MAKEWORD(2, 2);
+      WSAStartup(wVersionRequested, &wsaData);
+#endif // _WIN32
   }
   Logger::~Logger() {
     // delete not used messages.
@@ -48,6 +54,10 @@ namespace fluent {
     }
     std::for_each(this->queue_.begin(), this->queue_.end(),
                   [](MsgQueue* const &x) { delete x; });
+
+#ifdef _WIN32
+	  WSACleanup();
+#endif // _WIN32
   }
 
   void Logger::new_forward(const std::string &host, int port) {

--- a/src/queue.cc
+++ b/src/queue.cc
@@ -123,14 +123,14 @@ namespace fluent {
     ::pthread_mutex_lock (&(this->mutex_));
     debug(DBG, "entered lock");
 
-    debug(DBG, "PUSH: count:%lu, limit:%lu", this->count(), this->limit());
+    debug(DBG, "PUSH: count:%zu, limit:%zu", this->count(), this->limit());
     if (this->term_) {
       // do not accept more msg because working thread going to shutdown.
     } else {
       rc = this->MsgQueue::push(msg);
       ::pthread_cond_signal (&(this->cond_));
     }
-    debug(DBG, "PUSHED: count:%lu, limit:%lu", this->count(), this->limit());
+    debug(DBG, "PUSHED: count:%zu, limit:%zu", this->count(), this->limit());
     
     ::pthread_mutex_unlock (&(this->mutex_));
     debug(DBG, "left lock");

--- a/src/socket.cc
+++ b/src/socket.cc
@@ -51,7 +51,9 @@
 namespace fluent {
   Socket::Socket(const std::string &host, const std::string &port) :
     host_(host), port_(port), is_connected_(false) {
+#ifndef _WIN32
     signal(SIGPIPE, SIG_IGN);
+#endif
   }
   Socket::~Socket() {
     ::close(this->sock_);

--- a/src/socket.cc
+++ b/src/socket.cc
@@ -24,16 +24,23 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef _WIN32
+#include <winsock2.h>
+#include "windows.h"
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#endif
+
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <arpa/inet.h>
 #include <errno.h>
 #include <signal.h>
 

--- a/src/socket.cc
+++ b/src/socket.cc
@@ -50,7 +50,7 @@ namespace fluent {
     ::close(this->sock_);
   }
   bool Socket::connect() {
-    const bool DBG = false;
+    const bool DBG = true;
     bool rc = true;
     debug(DBG, "host=%s, port=%s", this->host_.c_str(), this->port_.c_str());
 


### PR DESCRIPTION
I have made various changes to the source to support windows. My current setup is to not use your cmake configuration and instead include the source files into our project. Therefore, I have no cmake changes in this.

High level:
 - use C++11 PRNG
 - localtime_r wasn't available, debug on windows doesn't include timestamp
 - windows sockets aren't file descriptors per se, don't call write() instead call send()
 - don't handle sigpipe
 - intialize and shutdown winsock