### PR TITLE
add check for skipping winsock startup/shutdown in library

### DIFF
--- a/src/fluent/emitter.hpp
+++ b/src/fluent/emitter.hpp
@@ -43,7 +43,7 @@ namespace fluent {
     virtual void worker() = 0;
     
   protected:
-    static const bool DBG = true;
+    static const bool DBG = false;
     MsgThreadQueue queue_;
     void set_errmsg(const std::string &errmsg) {
       this->errmsg_ = errmsg;

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -38,10 +38,12 @@
 namespace fluent {
   Logger::Logger() {
 #ifdef _WIN32
-      WORD wVersionRequested;
-      WSADATA wsaData;
-      wVersionRequested = MAKEWORD(2, 2);
-      WSAStartup(wVersionRequested, &wsaData);
+#ifndef FLUENTSKIPSTARTWINSOCK
+    WORD wVersionRequested;
+    WSADATA wsaData;
+    wVersionRequested = MAKEWORD(2, 2);
+    WSAStartup(wVersionRequested, &wsaData);
+#endif // FLUENTSKIPSTARTWINSOCK
 #endif // _WIN32
   }
   Logger::~Logger() {
@@ -56,7 +58,9 @@ namespace fluent {
                   [](MsgQueue* const &x) { delete x; });
 
 #ifdef _WIN32
-	  WSACleanup();
+#ifndef FLUENTSKIPSTARTWINSOCK
+    WSACleanup();
+#endif // FLUENTSKIPSTARTWINSOCK
 #endif // _WIN32
   }
 

--- a/src/socket.cc
+++ b/src/socket.cc
@@ -59,7 +59,7 @@ namespace fluent {
     ::close(this->sock_);
   }
   bool Socket::connect() {
-    const bool DBG = true;
+    const bool DBG = false;
     bool rc = true;
     debug(DBG, "host=%s, port=%s", this->host_.c_str(), this->port_.c_str());
 


### PR DESCRIPTION
This adds a `#ifndef` check to prevent the library from handling winsock startup and shutdown. This is needed as you should only startup and shutdown winsock from one spot. We've started needing more than just `libfluent` for networking, so we are managing winsock start/shutdown in our app.

The default behavior will still be as it was, for the library to handle startup and shutdown.

If this is undesired, simply define `FLUENTSKIPSTARTWINSOCK` for your build.